### PR TITLE
Use two instead of three dots for test plan

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,28 +9,31 @@ I wanted to experiment with Scheme a bit and unit testing with TAP is quite cool
 How?
 ====
 
-    (use-modules (guile-tap))
+```Scheme
+(use-modules (guile-tap))
 
-	(planned-tests 3)
+(planned-tests 3)
 
-	(ok (= 1 1))
-	(ok (not (null? '(21))))
+(ok (= 1 1))
+(ok (not (null? '(21))))
 
-	(diagnostic "Skip some tests...")
-    (skip #t
-     (list
-       '(ok (= 1 1))
-       '(ok (not (= 1 2))))
-	 ; Optional reason
-	 "A reason")
+(diagnostic "Skip some tests...")
+(skip #t
+  (list
+    '(ok (= 1 1))
+    '(ok (not (= 1 2))))
+  ; Optional reason
+  "A reason")
 
-	(diagnostic "Bail out...")
-	(bail-out!)
+(diagnostic "Bail out...")
+(bail-out!)
 
-	(diagnostic "Todo is supported as well...")
-	(todo
-	 (list
-	  '(ok (= 1 1)))
-	 ; Optional note
-	 "A note")
+(diagnostic "Todo is supported as well...")
+(todo
+  (list
+    '(ok (= 1 1)))
+    ; Optional note
+  "A note")
 
+(ok (throws? (/ 1 0)) "Test for exception")
+```

--- a/guile-tap.scm
+++ b/guile-tap.scm
@@ -16,7 +16,7 @@
 (define (print-total)
  (if (not printed-total)
   (begin
-   (format #t "~&1...~a" total-tests)
+   (format #t "~&1..~a" total-tests)
    (set! printed-total #t))))
 
 (define (incr-counter)

--- a/guile-tap.scm
+++ b/guile-tap.scm
@@ -1,8 +1,9 @@
 (define-module (guile-tap)
- :export (planned-tests ok bail-out! diagnostic skip todo)
+  #:export (planned-tests ok bail-out! diagnostic skip todo)
+  #:export-syntax (throws?)
 
 ; ~& in format strings
- :use-module (ice-9 format))
+  #:use-module (ice-9 format))
 
 ; Internal variables
 
@@ -81,3 +82,7 @@
  (lambda (tests . why)
   (do-directive tests "todo" why)))
 
+(define-syntax-rule (throws? expr)
+  (catch #t
+    (lambda () expr (throw 'test-failed))
+    (lambda (key . args) (case key ((test-failed) #f) (else #t)))))


### PR DESCRIPTION
Hi,
I think the TAP syntax is "1..3" instead of "1...3" for the test plan.
Also I added a 'throws?' macro which makes it possible to test for exceptions.

Regards
Jan
